### PR TITLE
fix: make footer navigation emojis prominent instead of faded

### DIFF
--- a/src/StoryStyles.twee
+++ b/src/StoryStyles.twee
@@ -71,13 +71,14 @@ tw-sidebar {
 	/* display: none; */ /* Uncomment to hide sidebar */
 }
 
-tw-icon {
+/* Navigation icons within sidebar - scoped to avoid affecting other tw-icon elements */
+tw-sidebar tw-icon {
 	opacity: 1 !important;
 	margin: 0 0 1rem;
 	font-size: 3rem;
 }
 
-tw-icon:hover {
+tw-sidebar tw-icon:hover {
 	opacity: 1 !important;
 }
 

--- a/src/StoryStyles.twee
+++ b/src/StoryStyles.twee
@@ -72,13 +72,13 @@ tw-sidebar {
 }
 
 tw-icon[alt] {
-	opacity: 1;
+	opacity: 1 !important;
 	margin: 0 0 1rem;
 	font-size: 3rem;
 }
 
 tw-icon[alt]:hover {
-	opacity: 1;
+	opacity: 1 !important;
 }
 
 /*

--- a/src/StoryStyles.twee
+++ b/src/StoryStyles.twee
@@ -71,13 +71,13 @@ tw-sidebar {
 	/* display: none; */ /* Uncomment to hide sidebar */
 }
 
-tw-icon[alt] {
+tw-icon {
 	opacity: 1 !important;
 	margin: 0 0 1rem;
 	font-size: 3rem;
 }
 
-tw-icon[alt]:hover {
+tw-icon:hover {
 	opacity: 1 !important;
 }
 


### PR DESCRIPTION
## Summary
- Override Harlowe's default `tw-icon` opacity (0.2) with `!important` to ensure forward/back navigation emojis display at full visibility

## Test plan
- [ ] Build the story and verify the footer navigation emojis (👈 and 👉) are fully visible, not faded

🤖 Generated with [Claude Code](https://claude.com/claude-code)